### PR TITLE
Add observability metrics for parallel execution conflicts and retries

### DIFF
--- a/src/main/java/com/worldmind/core/metrics/WorldmindMetrics.java
+++ b/src/main/java/com/worldmind/core/metrics/WorldmindMetrics.java
@@ -59,4 +59,92 @@ public class WorldmindMetrics {
                 .register(registry)
                 .increment();
     }
+
+    // --- Parallel Execution Observability ---
+
+    /**
+     * Records when a directive is deferred from a wave due to file overlap with another directive.
+     * Helps identify how often the scheduler serializes potentially conflicting directives.
+     *
+     * @param directiveId the directive that was deferred
+     */
+    public void recordFileOverlapDeferral(String directiveId) {
+        Counter.builder("worldmind.parallel.file_overlap_deferrals")
+                .description("Directives deferred due to file overlap conflicts")
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records a merge conflict that occurred during directive branch merging.
+     *
+     * @param directiveId the directive whose merge conflicted
+     * @param resolved    true if conflict was resolved via retry, false if directive must be re-executed
+     */
+    public void recordMergeConflict(String directiveId, boolean resolved) {
+        Counter.builder("worldmind.parallel.merge_conflicts")
+                .description("Merge conflicts during directive branch merging")
+                .tag("resolved", String.valueOf(resolved))
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records a successful merge retry.
+     * Incremented when a merge initially fails but succeeds on retry.
+     */
+    public void recordMergeRetrySuccess() {
+        Counter.builder("worldmind.parallel.merge_retry_success")
+                .description("Merge operations that succeeded on retry")
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records worktree operations for monitoring parallel execution health.
+     *
+     * @param operation "acquire", "release", or "cleanup"
+     * @param success   whether the operation succeeded
+     */
+    public void recordWorktreeOperation(String operation, boolean success) {
+        Counter.builder("worldmind.parallel.worktree_operations")
+                .description("Git worktree lifecycle operations")
+                .tag("operation", operation)
+                .tag("success", String.valueOf(success))
+                .register(registry)
+                .increment();
+    }
+
+    /**
+     * Records the number of active worktrees for a mission.
+     * Useful for tracking resource usage during parallel execution.
+     *
+     * @param count number of active worktrees
+     */
+    public void recordActiveWorktrees(int count) {
+        DistributionSummary.builder("worldmind.parallel.active_worktrees")
+                .description("Number of active worktrees per wave")
+                .register(registry)
+                .record(count);
+    }
+
+    /**
+     * Records wave execution metrics for parallel vs sequential analysis.
+     *
+     * @param directiveCount number of directives in the wave
+     * @param strategy       "parallel" or "sequential"
+     */
+    public void recordWaveExecution(int directiveCount, String strategy) {
+        Counter.builder("worldmind.wave.executions")
+                .description("Wave executions by strategy")
+                .tag("strategy", strategy)
+                .register(registry)
+                .increment();
+
+        DistributionSummary.builder("worldmind.wave.directive_count")
+                .description("Number of directives per wave")
+                .tag("strategy", strategy)
+                .register(registry)
+                .record(directiveCount);
+    }
 }

--- a/src/main/java/com/worldmind/starblaster/StarblasterConfig.java
+++ b/src/main/java/com/worldmind/starblaster/StarblasterConfig.java
@@ -4,7 +4,9 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.zerodep.ZerodepDockerHttpClient;
+import com.worldmind.core.metrics.WorldmindMetrics;
 import com.worldmind.starblaster.cf.GitWorkspaceManager;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,7 +44,8 @@ public class StarblasterConfig {
      * preventing file conflicts during parallel execution.
      */
     @Bean
-    public WorktreeExecutionContext worktreeExecutionContext(GitWorkspaceManager gitWorkspaceManager) {
-        return new WorktreeExecutionContext(gitWorkspaceManager);
+    public WorktreeExecutionContext worktreeExecutionContext(GitWorkspaceManager gitWorkspaceManager,
+                                                              @Autowired(required = false) WorldmindMetrics metrics) {
+        return new WorktreeExecutionContext(gitWorkspaceManager, metrics);
     }
 }


### PR DESCRIPTION
## Summary
- Adds new metrics to `WorldmindMetrics` for monitoring parallel execution performance and conflicts
- Integrates metrics recording into `ScheduleWaveNode` for wave execution tracking
- Integrates metrics recording into `WorktreeExecutionContext` for worktree lifecycle tracking
- Updates `StarblasterConfig` to wire metrics into `WorktreeExecutionContext`

### New Metrics
| Metric | Type | Description |
|--------|------|-------------|
| `worldmind.parallel.file_overlap_deferrals` | Counter | Directives deferred due to file overlap conflicts |
| `worldmind.parallel.merge_conflicts` | Counter | Merge conflicts by resolution status |
| `worldmind.parallel.merge_retry_success` | Counter | Successful merge retries |
| `worldmind.parallel.worktree_operations` | Counter | Worktree operations (acquire/release/cleanup) by success |
| `worldmind.parallel.active_worktrees` | Gauge | Active worktree count at wave execution |
| `worldmind.wave.executions` | Counter | Wave executions by strategy (sequential/parallel) |
| `worldmind.wave.directive_count` | DistributionSummary | Number of directives per wave by strategy |

## Test plan
- [x] Code compiles successfully
- [x] No new linter errors
- [ ] Metrics can be verified via /actuator/prometheus endpoint when running

Closes #7

Made with [Cursor](https://cursor.com)